### PR TITLE
Evaluate values when prefixed with operator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["latest"],
+  "presets": ["env"],
   "plugins": [
     "add-module-exports",
     "transform-es2015-modules-umd"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,30 @@
+{
+  "parser": "babel-eslint",
+  "extends": [
+    "eslint:recommended",
+    "plugin:mocha/recommended"
+   ],
+  "plugins": ["mocha"],
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "modules": true,
+      "classes": true
+    }
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true,
+    "jasmine": true
+  },
+  "rules": {
+    "no-undef": 2,
+    "strict": [2, "global"],
+    "no-underscore-dangle": 0,
+    "eqeqeq": "error",
+    "no-eq-null": "error",
+    "no-loop-func": "error",
+    "no-duplicate-imports": "error"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -21,26 +21,31 @@ This gives the possibility to...
 
 ## Examples
 
-* `{a:'[25 TO 250]'} => "a BETWEEN '25' AND '250` *(?a=[25 TO 250])*
-* `{x[{a:'>25'},{b:'<100'}]} => "a > 25 OR b <  100"`*(?x[a]=>25&x[b]=<100)*
+* `{a:'[25 TO 250]'} => "a BETWEEN 25 AND 250"` *(?a=[25 TO 250])*
+* `{x[{a:'>25'},{b:'<100'}]} => "a > 25 OR b < 100"` *(?x[a]=>25&x[b]=<100)*
 
 
-NOTE: in last example ***x*** is ignored because it's pointing to array of values (or statement). Keys pointing to Object or Array are ignored from statement.
+> NOTE: in last example ***x*** is ignored because it's pointing to array of values (or statement). Keys pointing to Object or Array are ignored from statement.
 
 
 ## Supported values
 
-* **{a:null}** or **{a:'null'}** –> `a IS NULL`
-* **{a:'!null'}** –> `a IS NOT NULL`
-* **{a:'value'}** –> `a = 'value'`
-* **{a:'!value'}** –> `a <> 'value'`
-* **{a:'>25'}** –> `a > '25'`
-* **{a:'<25'}** –> `a < '25'`
-* **{a:'>=25'}** –> `a >= '25'`
-* **{a:'<=25'}** –> `a <= '25'`
-* **{a:'[2 TO 200]'}** –> `a BETWEEN '2' AND '200'`
-* **{a:'[1,2,3,aa]'}** –> `a IN ('1','2','3','aa')`
-* **{a:'He?lo wor\*'}** –> `a LIKE 'He_lo wor%'`
+* **{a: null}** or **{a: 'null'}** –> `a IS NULL`
+* **{a: '!null'}** –> `a IS NOT NULL`
+* **{a: 'value'}** –> `a = 'value'`
+* **{a: '!value'}** –> `a <> 'value'`
+* **{a: '>25'}** –> `a > 25`
+* **{a: '<25'}** –> `a < 25`
+* **{a: '>=25'}** –> `a >= 25`
+* **{a: '<=25'}** –> `a <= 25`
+* **{a: '<="25"'}** –> `a <= '25'`
+* **{a: '[2 TO 200]'}** –> `a BETWEEN 2 AND 200`
+* **{a: '[1, 2, 3]'}** –> `a IN (1 , 2 , 3)`
+* **{a: '[a, b, c]'}** –> `a IN ('a', 'b', 'c')`
+* **{a: 'He?lo wor\*'}** –> `a LIKE 'He_lo wor%'`
+
+Note that values are evaulated to JavaScript `number` type if it's a valid number otherwise they are evaluated to a `string` type. However in the situation you wanto to coerce a number into a string wrap it around double quotes `"`.
+
 
 ## Running tests
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-eslint": "~7.2.3",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-transform-es2015-modules-umd": "~6.24.1",
-    "babel-preset-latest": "~6.24.1",
+    "babel-preset-env": "~1.4.0",
     "eslint": "~3.19.0",
     "eslint-plugin-mocha": "~4.9.0",
     "mocha": "~3.3.0"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
   "devDependencies": {
     "babel-cli": "~6.24.1",
     "babel-core": "~6.24.1",
+    "babel-eslint": "~7.2.3",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-transform-es2015-modules-umd": "~6.24.1",
     "babel-preset-latest": "~6.24.1",
+    "eslint": "~3.19.0",
+    "eslint-plugin-mocha": "~4.9.0",
     "mocha": "~3.3.0"
   },
   "main": "dist/sql-condition-builder.js",

--- a/src/sql-condition-builder.js
+++ b/src/sql-condition-builder.js
@@ -1,61 +1,61 @@
-import squel from 'squel';
+import squel from 'squel'
 
 
 export default class SQLConditionBuilder {
   constructor() {
-    this.valueFormatters = [];
+    this.valueFormatters = []
 
     this.registerValueFormatter(null, value => {  // eslint-disable-line no-unused-vars
-      return 'IS NULL';
-    });
+      return 'IS NULL'
+    })
     this.registerValueFormatter('null', value => {  // eslint-disable-line no-unused-vars
-      return 'IS NULL';
-    });
+      return 'IS NULL'
+    })
     this.registerValueFormatter('!null', value => {  // eslint-disable-line no-unused-vars
-      return 'IS NOT NULL';
-    });
+      return 'IS NOT NULL'
+    })
     this.registerValueFormatter('>=', value => {
-      return `>= ${this._escapeValue(value.substring(2))}`;
-    });
+      return `>= ${this._escapeValue(value.substring(2))}`
+    })
     this.registerValueFormatter('>', value => {
-      return `> ${this._escapeValue(value.substring(1))}`;
-    });
+      return `> ${this._escapeValue(value.substring(1))}`
+    })
     this.registerValueFormatter('<=', value => {
-      return `<= ${this._escapeValue(value.substring(2))}`;
-    });
+      return `<= ${this._escapeValue(value.substring(2))}`
+    })
     this.registerValueFormatter('<', value => {
-      return `< ${this._escapeValue(value.substring(1))}`;
-    });
+      return `< ${this._escapeValue(value.substring(1))}`
+    })
     this.registerValueFormatter('!', value => {
-      return `<> ${this._escapeValue(value.substring(1))}`;
-    });
+      return `<> ${this._escapeValue(value.substring(1))}`
+    })
     this.registerValueFormatter(/[\*\?]+/, value => {
-      return `LIKE ${this._escapeValue(value.replace(/\*/g, '%').replace(/\?/, '_'))}`;
-    });
+      return `LIKE ${this._escapeValue(value.replace(/\*/g, '%').replace(/\?/, '_'))}`
+    })
     this.registerValueFormatter(/\[.+ TO .+\]/, value => {
-      let splitted = value.substring(1, value.length - 1).split(' TO ');
-      return `BETWEEN ${this._escapeValue(splitted[0])} AND ${this._escapeValue(splitted[1])}`;
-    });
+      const splitted = value.substring(1, value.length - 1).split(' TO ')
+      return `BETWEEN ${this._escapeValue(splitted[0])} AND ${this._escapeValue(splitted[1])}`
+    })
     this.registerValueFormatter(/\[(.+,)*.+\]/, value => {
-      let values = value.substring(1, value.length - 1).split(',');
-      return `IN (${values.map(item => this._escapeValue(item.replace(/^["]+|["]+$/g, "")))})`;
-    });
+      const values = value.substring(1, value.length - 1).split(',')
+      return `IN (${values.map(item => this._escapeValue(item.replace(/^["]+|["]+$/g, "")))})`
+    })
   }
 
   build(object) {
-    let expr = this.getExpression(object);
-    return expr.toString();
+    return this.getExpression(object).toString()
   }
 
   getExpression(objectOrArray) {
-    let expr = squel.expr();
+    const expr = squel.expr()
+
     if (Array.isArray(objectOrArray)) {
-      this._buildExpressionWithArray(expr, objectOrArray);
+      this._buildExpressionWithArray(expr, objectOrArray)
     } else {
-      this._buildExpressionWithObject(expr, objectOrArray);
+      this._buildExpressionWithObject(expr, objectOrArray)
     }
 
-    return expr;
+    return expr
   }
 
 
@@ -64,57 +64,58 @@ export default class SQLConditionBuilder {
       value instanceof Object ?
         expr.or(this.build(value))
         :
-        expr.or(value));
+        expr.or(value))
   }
 
   _buildExpressionWithObject(expr, object) {
     return (() => {
-      let result = [];
-      for (let key in object) {
-        let value = object[key];
+      const result = []
+
+      for (const key in object) {
+        const value = object[key]
+
         if (value instanceof Object) {
-          result.push(expr.and(`(${this.build(value)})`));
+          result.push(expr.and(`(${this.build(value)})`))
         } else {
-          let parsedValue = this._parseValue(value);
+          const parsedValue = this._parseValue(value)
+
           if (parsedValue) {
-            result.push(expr.and(key + ' ' + parsedValue));
+            result.push(expr.and(`${key} ${parsedValue}`))
           } else {
-            result.push(expr.and(key + ' = ' + this._escapeValue(value)));
+            result.push(expr.and(`${key} = ${this._escapeValue(value)}`))
           }
         }
       }
-      return result;
-    })();
+
+      return result
+    })()
   }
 
 
   _parseValue(value) {
-    for (let f of Array.from(this.valueFormatters)) {
+    for (const f of Array.from(this.valueFormatters)) {
       if (f.format instanceof RegExp && f.format.test(value)) {
-        return f.fn(value);
+        return f.fn(value)
       } else if ((value === f.format) || (value && ((typeof value.indexOf === 'function' ? value.indexOf(f.format) : undefined) === 0))) {
-        return f.fn(value);
+        return f.fn(value)
       }
     }
-    return null;
+    return null
   }
 
 
   registerValueFormatter(formatOrPrefix, formatterFunction) {
-    return this.valueFormatters.push({ format: formatOrPrefix, fn: formatterFunction });
+    return this.valueFormatters.push({ format: formatOrPrefix, fn: formatterFunction })
   }
 
   _escapeValue(value) {
-    if (typeof value !== 'string') {
-      return value;
-    }
-    return this._wrapStringValue(value.replace(/\'/g, '\\\''));
+    return typeof value !== 'string' ?
+      value
+      :
+      this._wrapStringValue(value.replace(/\'/g, '\\\''))
   }
 
   _wrapStringValue(value) {
-    if (value[0] === '`') {
-      return value;
-    }
-    return `'${value}'`;
+    return value[0] === '`' ? value : `'${value}'`
   }
 }

--- a/src/sql-condition-builder.js
+++ b/src/sql-condition-builder.js
@@ -5,13 +5,13 @@ export default class SQLConditionBuilder {
   constructor() {
     this.valueFormatters = [];
 
-    this.registerValueFormatter(null, value => {
+    this.registerValueFormatter(null, value => {  // eslint-disable-line no-unused-vars
       return 'IS NULL';
     });
-    this.registerValueFormatter('null', value => {
+    this.registerValueFormatter('null', value => {  // eslint-disable-line no-unused-vars
       return 'IS NULL';
     });
-    this.registerValueFormatter('!null', value => {
+    this.registerValueFormatter('!null', value => {  // eslint-disable-line no-unused-vars
       return 'IS NOT NULL';
     });
     this.registerValueFormatter('>=', value => {

--- a/test.js
+++ b/test.js
@@ -1,40 +1,41 @@
-import assert from 'assert';
+import assert from 'assert'
 
-import SQLConditionBuilder from './src/sql-condition-builder';
+import SQLConditionBuilder from './src/sql-condition-builder'
 
 
-var builder = new SQLConditionBuilder();
+const builder = new SQLConditionBuilder()
 
-describe("plain content", function () {
-  it("should generate correct condition from object", function () {
-    var obj = { test: "xxx", hello: "wor'ld", number: 25 };
-    var cond = builder.build(obj);
+describe("plain content", () => {
+  it("should generate correct condition from object", () => {
+    const obj = { test: "xxx", hello: "wor'ld", number: 25 }
+    const cond = builder.build(obj)
 
-    assert.equal(cond, "test = 'xxx' AND hello = 'wor\\'ld' AND number = 25");
-  });
-  it("should generate correct condition from array", function () {
-    var arr = ["test='xxx'", "hello='world'", "number=25", "value=`value`"];
-    var cond = builder.build(arr);
+    assert.equal(cond, "test = 'xxx' AND hello = 'wor\\'ld' AND number = 25")
+  })
 
-    assert.equal(cond, "test='xxx' OR hello='world' OR number=25 OR value=`value`");
-  });
-});
+  it("should generate correct condition from array", () => {
+    const arr = ["test='xxx'", "hello='world'", "number=25", "value=`value`"]
+    const cond = builder.build(arr)
 
-describe("nested content", function () {
-  it("should generate correct condition from nested objects/arrays", function () {
-    var obj = { ignoredKey: [{ aa: "aa", bb: "bb" }, { xx: "yy", yy: "xx" }], test: 125 };
-    var arr = [{ ignoredKey: [{ aa: "aa", bb: "bb" }, { xx: "yy", yy: "xx" }] }, { test: 125 }];
-    var cond = builder.build(obj);
-    var cond2 = builder.build(arr);
+    assert.equal(cond, "test='xxx' OR hello='world' OR number=25 OR value=`value`")
+  })
+})
 
-    assert.equal(cond, "(aa = 'aa' AND bb = 'bb' OR xx = 'yy' AND yy = 'xx') AND test = 125");
-    assert.equal(cond2, "(aa = 'aa' AND bb = 'bb' OR xx = 'yy' AND yy = 'xx') OR test = 125");
-  });
-});
+describe("nested content", () => {
+  it("should generate correct condition from nested objects/arrays", () => {
+    const obj = { ignoredKey: [{ aa: "aa", bb: "bb" }, { xx: "yy", yy: "xx" }], test: 125 }
+    const arr = [{ ignoredKey: [{ aa: "aa", bb: "bb" }, { xx: "yy", yy: "xx" }] }, { test: 125 }]
+    const cond = builder.build(obj)
+    const cond2 = builder.build(arr)
 
-describe("value parsers", function () {
-  it("should parse basic content", function () {
-    var obj = {
+    assert.equal(cond, "(aa = 'aa' AND bb = 'bb' OR xx = 'yy' AND yy = 'xx') AND test = 125")
+    assert.equal(cond2, "(aa = 'aa' AND bb = 'bb' OR xx = 'yy' AND yy = 'xx') OR test = 125")
+  })
+})
+
+describe("value parsers", () => {
+  it("should parse basic content", () => {
+    const obj = {
       less: "<25",
       lessEq: "<=52",
       more: ">125",
@@ -46,21 +47,21 @@ describe("value parsers", function () {
       in: "[1,2,aa]",
       in2: "[aa]",
       in3: '["aa","bb"]'
-    };
-    var cond = builder.build(obj);
+    }
+    const cond = builder.build(obj)
 
     assert.equal(
       cond,
       "less < '25' AND lessEq <= '52' AND more > '125' AND moreEq >= '521' AND notEqual <> 'ahoj' AND equal = 'svete' AND like LIKE 'li%k_' AND between BETWEEN '10' AND '1000' AND in IN ('1','2','aa') AND in2 IN ('aa') AND in3 IN ('aa','bb')"
-    );
-  });
-});
+    )
+  })
+})
 
-describe("null values", function () {
-  it("should recognize null comparisons", function () {
-    var obj = { a: null, b: "null", c: "!null" };
-    var cond = builder.build(obj);
+describe("null values", () => {
+  it("should recognize null comparisons", () => {
+    const obj = { a: null, b: "null", c: "!null" }
+    const cond = builder.build(obj)
 
-    assert.equal(cond, "a IS NULL AND b IS NULL AND c IS NOT NULL");
-  });
-});
+    assert.equal(cond, "a IS NULL AND b IS NULL AND c IS NOT NULL")
+  })
+})

--- a/test.js
+++ b/test.js
@@ -34,26 +34,70 @@ describe("nested content", () => {
 })
 
 describe("value parsers", () => {
-  it("should parse basic content", () => {
-    const obj = {
-      less: "<25",
-      lessEq: "<=52",
-      more: ">125",
-      moreEq: ">=521",
-      notEqual: "!ahoj",
-      equal: "svete",
-      like: "li*k?",
-      between: "[10 TO 1000]",
-      in: "[1,2,aa]",
-      in2: "[aa]",
-      in3: '["aa","bb"]'
-    }
+  it("should parse in", () => {
+    const obj = { inNumber: '[1, 2]', inString: '[a, b]', inQuoted: '["1", "2"]' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "inNumber IN (1, 2) AND inString IN ('a', 'b') AND inQuoted IN ('1', '2')")
+  })
+
+  it("should parse between", () => {
+    const obj = { btNumber: '[10 TO 1000]', btString: '[a TO z]', btQuoted: '["1" TO "10"]' }
     const cond = builder.build(obj)
 
     assert.equal(
       cond,
-      "less < '25' AND lessEq <= '52' AND more > '125' AND moreEq >= '521' AND notEqual <> 'ahoj' AND equal = 'svete' AND like LIKE 'li%k_' AND between BETWEEN '10' AND '1000' AND in IN ('1','2','aa') AND in2 IN ('aa') AND in3 IN ('aa','bb')"
+      "btNumber BETWEEN 10 AND 1000 AND btString BETWEEN 'a' AND 'z' AND btQuoted BETWEEN '1' AND '10'"
     )
+  })
+
+  it("should parse like", () => {
+    const obj = { like: 'li*k?' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "like LIKE 'li%k_'")
+  })
+
+  it("should parse not equal", () => {
+    const obj = { neNumber: '!25', neString: '!aa', neQuoted: '!"25"' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "neNumber <> 25 AND neString <> 'aa' AND neQuoted <> '25'")
+  })
+
+  it("should parse equal", () => {
+    const obj = { eqNumber: 25, eqStrNumber: '25', eqString: 'aa' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "eqNumber = 25 AND eqStrNumber = '25' AND eqString = 'aa'")
+  })
+
+  it("should parse greater or equal than", () => {
+    const obj = { geNumber: '>=25', geString: '>=aa', geQuoted: '>="25"' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "geNumber >= 25 AND geString >= 'aa' AND geQuoted >= '25'")
+  })
+
+  it("should parse greater than", () => {
+    const obj = { gtNumber: '>25', gtString: '>aa', gtQuoted: '>"25"' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "gtNumber > 25 AND gtString > 'aa' AND gtQuoted > '25'")
+  })
+
+  it("should parse less or equal than", () => {
+    const obj = { leNumber: '<=25', leString: '<=aa', leQuoted: '<="25"' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "leNumber <= 25 AND leString <= 'aa' AND leQuoted <= '25'")
+  })
+
+  it("should parse less than", () => {
+    const obj = { ltNumber: '<25', ltString: '<aa', ltQuoted: '<"25"' }
+    const cond = builder.build(obj)
+
+    assert.equal(cond, "ltNumber < 25 AND ltString < 'aa' AND ltQuoted < '25'")
   })
 })
 


### PR DESCRIPTION
> This is a potential breaking change so I suggest to bump the major version to 0.2

Values prefixed with operators like `< <= => > !` are always rendered as string even if they are obviously numbers (i.e. `">25"` to `> '25'` instead of `> 25`). This PR fixes the issue by evaluating the value and convert it into a JavaScript `number` type before rendering the condition.