### PR TITLE
Restricting 'in' conditions to allow literal brackets as text

### DIFF
--- a/dist/sql-condition-builder.js
+++ b/dist/sql-condition-builder.js
@@ -125,7 +125,7 @@
       this.registerValueFormatter(/[\*\?]+/, function (value) {
         return 'LIKE ' + _this._evalAndEscapeValue(value.replace(/\*/g, '%').replace(/\?/, '_'));
       });
-      this.registerValueFormatter(/\[.+ TO .+\]/, function (value) {
+      this.registerValueFormatter(/^\[.+ TO .+\]$/, function (value) {
         var splitted = value.substring(1, value.length - 1).split(' TO ').map(function (item) {
           return _this._evalAndEscapeValue(item);
         });
@@ -136,7 +136,7 @@
 
         return 'BETWEEN ' + fromValue + ' AND ' + toValue;
       });
-      this.registerValueFormatter(/\[(.+,)*.+\]/, function (value) {
+      this.registerValueFormatter(/^\[(.+,)*.+\]$/, function (value) {
         var values = value.substring(1, value.length - 1).split(',').map(function (item) {
           return item.trim();
         }).map(function (item) {

--- a/src/sql-condition-builder.js
+++ b/src/sql-condition-builder.js
@@ -32,7 +32,7 @@ export default class SQLConditionBuilder {
     this.registerValueFormatter(/[\*\?]+/, value => {
       return `LIKE ${this._evalAndEscapeValue(value.replace(/\*/g, '%').replace(/\?/, '_'))}`
     })
-    this.registerValueFormatter(/\[.+ TO .+\]/, value => {
+    this.registerValueFormatter(/^\[.+ TO .+\]$/, value => {
       const splitted = value
         .substring(1, value.length - 1)
         .split(' TO ')
@@ -42,7 +42,7 @@ export default class SQLConditionBuilder {
 
       return `BETWEEN ${fromValue} AND ${toValue}`
     })
-    this.registerValueFormatter(/\[(.+,)*.+\]/, value => {
+    this.registerValueFormatter(/^\[(.+,)*.+\]$/, value => {
       const values = value
         .substring(1, value.length - 1)
         .split(',')

--- a/test.js
+++ b/test.js
@@ -40,6 +40,12 @@ describe("value parsers", () => {
 
     assert.equal(cond, "inNumber IN (1, 2) AND inString IN ('a', 'b') AND inQuoted IN ('1', '2')")
   })
+  it("should not parse in for text brackets", () => {
+    const obj = { inString: "[a, b]", notInString: "prefix [text] sufix" };
+    const cond = builder.build(obj);
+
+    assert.equal(cond, "inString IN ('a', 'b') AND notInString = 'prefix [text] sufix'");
+  });
 
   it("should parse between", () => {
     const obj = { btNumber: '[10 TO 1000]', btString: '[a TO z]', btQuoted: '["1" TO "10"]' }


### PR DESCRIPTION
Just adding a small fix to issues like:

`
builder.build({"txt":"prefix -[text inside brackets:]_sufix"}));
`

Result:
`
txt IN ('refix -[text inside brackets:]_sufi')
`

Expected result:
`
txt = 'prefix -[text inside brackets:]_sufix'
`